### PR TITLE
skip adding fmt or uuid import when it's already presents in the file

### DIFF
--- a/generator/repository/repository_combined_template.tmpl
+++ b/generator/repository/repository_combined_template.tmpl
@@ -14,8 +14,10 @@ import (
 
 	"github.com/AugustineAurelius/eos/pkg/generics"
 	sq "github.com/Masterminds/squirrel"
-	{{- range .Imports }}
-	{{ . }}
+	{{- range $imp := .Imports }}
+	  {{ if and (ne $imp "\"fmt\"") (ne $imp "\"github.com/google/uuid\"") }}
+        {{- $imp }}
+      {{ end }}
 	{{- end }}
 )
 


### PR DESCRIPTION
fixed bug with doubled import when "fmt" or "github.com/google/uuid" package already present in the model file